### PR TITLE
Add table config form

### DIFF
--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,2 +1,1 @@
-<app-nx-welcome></app-nx-welcome>
 <router-outlet></router-outlet>

--- a/src/app/app.routes.ts
+++ b/src/app/app.routes.ts
@@ -1,3 +1,6 @@
 import { Route } from '@angular/router';
+import { TableConfigFormComponent } from './table-config-form.component';
 
-export const appRoutes: Route[] = [];
+export const appRoutes: Route[] = [
+  { path: '', component: TableConfigFormComponent },
+];

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,20 +1,15 @@
 import { TestBed } from '@angular/core/testing';
 import { App } from './app';
-import { NxWelcome } from './nx-welcome';
 
 describe('App', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [App, NxWelcome],
+      imports: [App],
     }).compileComponents();
   });
 
-  it('should render title', () => {
+  it('should create', () => {
     const fixture = TestBed.createComponent(App);
-    fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain(
-      'Welcome goal-editor'
-    );
+    expect(fixture).toBeTruthy();
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,13 +1,10 @@
 import { Component } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { NxWelcome } from './nx-welcome';
 
 @Component({
-  imports: [NxWelcome, RouterModule],
+  imports: [RouterModule],
   selector: 'app-root',
   templateUrl: './app.html',
   styleUrl: './app.scss',
 })
-export class App {
-  protected title = 'goal-editor';
-}
+export class App {}

--- a/src/app/database/database.service.ts
+++ b/src/app/database/database.service.ts
@@ -1,0 +1,28 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class DatabaseService {
+  async getDatabases(): Promise<string[]> {
+    return Promise.resolve(['db1', 'db2', 'db3']);
+  }
+
+  async getTables(database: string): Promise<string[]> {
+    const tables: Record<string, string[]> = {
+      db1: ['table1', 'table2'],
+      db2: ['table3', 'table4'],
+      db3: ['table5'],
+    };
+    return Promise.resolve(tables[database] || []);
+  }
+
+  async getColumns(database: string, table: string): Promise<string[]> {
+    const cols: Record<string, Record<string, string[]>> = {
+      db1: { table1: ['id', 'name', 'value'], table2: ['id', 'title'] },
+      db2: { table3: ['id', 'desc'], table4: ['id', 'data'] },
+      db3: { table5: ['id', 'col'] },
+    };
+    return Promise.resolve(cols[database]?.[table] || []);
+  }
+}

--- a/src/app/roles.enum.ts
+++ b/src/app/roles.enum.ts
@@ -1,0 +1,5 @@
+export enum Roles {
+  Admin = 'admin',
+  Editor = 'editor',
+  Viewer = 'viewer',
+}

--- a/src/app/table-config-form.component.html
+++ b/src/app/table-config-form.component.html
@@ -1,0 +1,53 @@
+<form [formGroup]="form" class="table-form">
+  <mat-form-field appearance="fill">
+    <input
+      type="text"
+      matInput
+      placeholder="Database"
+      formControlName="database"
+      [matAutocomplete]="dbAuto"
+    />
+    <mat-autocomplete #dbAuto="matAutocomplete">
+      <mat-option *ngFor="let db of databases" [value]="db">{{ db }}</mat-option>
+    </mat-autocomplete>
+  </mat-form-field>
+
+  <mat-form-field appearance="fill">
+    <input
+      type="text"
+      matInput
+      placeholder="Tabela"
+      formControlName="table"
+      [matAutocomplete]="tableAuto"
+    />
+    <mat-autocomplete #tableAuto="matAutocomplete">
+      <mat-option *ngFor="let table of tables" [value]="table">{{ table }}</mat-option>
+    </mat-autocomplete>
+  </mat-form-field>
+
+  <mat-form-field appearance="fill">
+    <mat-select placeholder="Colunas Editáveis" formControlName="editableColumns" multiple>
+      <mat-option *ngFor="let c of columns" [value]="c">{{ c }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field appearance="fill">
+    <mat-select placeholder="Colunas de Visualização" formControlName="viewColumns" multiple>
+      <mat-option *ngFor="let c of columns" [value]="c">{{ c }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field appearance="fill">
+    <mat-select placeholder="Tipo de Dado" formControlName="dataType">
+      <mat-option value="string">string</mat-option>
+      <mat-option value="number">number</mat-option>
+      <mat-option value="date">date</mat-option>
+    </mat-select>
+  </mat-form-field>
+
+  <mat-form-field appearance="fill">
+    <mat-select placeholder="Grupos" formControlName="roles" multiple>
+      <mat-option *ngFor="let role of roles" [value]="role">{{ role }}</mat-option>
+    </mat-select>
+  </mat-form-field>
+</form>

--- a/src/app/table-config-form.component.scss
+++ b/src/app/table-config-form.component.scss
@@ -1,0 +1,6 @@
+.table-form {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  width: 400px;
+}

--- a/src/app/table-config-form.component.ts
+++ b/src/app/table-config-form.component.ts
@@ -1,0 +1,79 @@
+import { Component, OnInit } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { DatabaseService } from './database/database.service';
+import { Roles } from './roles.enum';
+import { debounceTime, switchMap, tap } from 'rxjs/operators';
+import { of } from 'rxjs';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatInputModule } from '@angular/material/input';
+import { MatAutocompleteModule } from '@angular/material/autocomplete';
+import { MatSelectModule } from '@angular/material/select';
+import { MatOptionModule } from '@angular/material/core';
+import { MatButtonModule } from '@angular/material/button';
+import { NgFor } from '@angular/common';
+
+@Component({
+  selector: 'app-table-config-form',
+  standalone: true,
+  imports: [
+    CommonModule,
+    ReactiveFormsModule,
+    MatFormFieldModule,
+    MatInputModule,
+    MatAutocompleteModule,
+    MatSelectModule,
+    MatOptionModule,
+    MatButtonModule,
+    NgFor,
+  ],
+  templateUrl: './table-config-form.component.html',
+  styleUrl: './table-config-form.component.scss',
+})
+export class TableConfigFormComponent implements OnInit {
+  roles = Object.values(Roles);
+  databases: string[] = [];
+  tables: string[] = [];
+  columns: string[] = [];
+
+  form = new FormGroup({
+    database: new FormControl(''),
+    table: new FormControl(''),
+    editableColumns: new FormControl<string[]>([]),
+    viewColumns: new FormControl<string[]>([]),
+    dataType: new FormControl(''),
+    roles: new FormControl<string[]>([]),
+  });
+
+  constructor(private dbService: DatabaseService) {}
+
+  ngOnInit(): void {
+    this.loadDatabases();
+    this.form
+      .get('database')!
+      .valueChanges.pipe(
+        debounceTime(300),
+        tap(() => {
+          this.tables = [];
+          this.form.get('table')!.reset();
+        }),
+        switchMap((db) => (db ? this.dbService.getTables(db) : of([])))
+      )
+      .subscribe((tables) => (this.tables = tables));
+
+    this.form
+      .get('table')!
+      .valueChanges.pipe(
+        debounceTime(300),
+        switchMap((table) => {
+          const db = this.form.get('database')!.value;
+          return db && table ? this.dbService.getColumns(db, table) : of([]);
+        })
+      )
+      .subscribe((cols) => (this.columns = cols));
+  }
+
+  private async loadDatabases() {
+    this.databases = await this.dbService.getDatabases();
+  }
+}


### PR DESCRIPTION
## Summary
- add a table configuration form with Angular Material widgets
- provide a mock `DatabaseService` and `Roles` enum
- route root path to the table configuration form
- clean up the app component
- update unit test

## Testing
- `npm test` *(fails: nx not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501f6d38f48321ab07d7fb0dafb1f4